### PR TITLE
connection.py can now be used in other apps

### DIFF
--- a/examples/count_all_the_sales/manage.py
+++ b/examples/count_all_the_sales/manage.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python
 """This is the main entry point for running analytics scripts."""
 
-import os
-
 from pylytics.library.main import main
 
 
 if __name__ == "__main__":
-    os.environ.setdefault('PROJECT_PATH',
-                          os.path.dirname(os.path.abspath(__file__)))
     main()

--- a/pylytics/conf/project_template/manage.py
+++ b/pylytics/conf/project_template/manage.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python
 """This is the main entry point for running analytics scripts."""
 
-import os
-
 from pylytics.library.main import main
 
 
 if __name__ == "__main__":
-    os.environ.setdefault('PROJECT_PATH',
-                          os.path.dirname(os.path.abspath(__file__)))
     main()

--- a/pylytics/library/connection.py
+++ b/pylytics/library/connection.py
@@ -4,7 +4,7 @@ Utilities for making database connections easier.
 
 import MySQLdb
 
-from main import settings
+import settings
 
 
 def run_query(database, query):
@@ -46,7 +46,8 @@ class DB(object):
 
     def connect(self):
         if not self.connection:
-            self.connection = MySQLdb.connect(**settings.DATABASES[self.database])
+            self.connection = MySQLdb.connect(
+                    **settings.DATABASES[self.database])
 
     def close(self):
         """You should always call this after opening a connection."""

--- a/pylytics/library/main.py
+++ b/pylytics/library/main.py
@@ -1,17 +1,12 @@
 # Add the project settings module to the namespace.
 
+import argparse
 import importlib
 import os
-
-settings = importlib.import_module('settings',
-                                   package=os.environ.get('PROJECT_PATH'))
-
-###############################################################################
-
-import argparse
 import sys
 
 from connection import DB
+import settings
 from utils import underscore_to_camelcase
 
 


### PR DESCRIPTION
There was some redundant path manipulation.

When manage.py is executed, the parent directory is automatically added to the python path.
