### PR TITLE
View fixes

### DIFF
--- a/pylytics/library/fact.py
+++ b/pylytics/library/fact.py
@@ -408,7 +408,7 @@ class Fact(Table):
             dim_table = dim_class.table_name
             columns.extend(
                 "`%s`.`%s` AS %s" % (
-                    dim_table,
+                    self.dim_names[i],
                     column,
                     column_name(self.dim_names[i], column)
                     ) for column in dim_class.column_names[1:-1]


### PR DESCRIPTION
There was a problem with automatic view creation when using a Fact which referenced a dimension twice.

An example is a fact which has two columns which reference dim_date (e.g. one representing date the fact was run, and the other something like a booking date).
