### PR TITLE
Unicode literals

### DIFF
--- a/pylytics/library/dimension.py
+++ b/pylytics/library/dimension.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import datetime
 
 from column import *

--- a/pylytics/library/fact.py
+++ b/pylytics/library/fact.py
@@ -73,7 +73,7 @@ class Fact(Table):
         for dimension_key in cls.__dimensionkeys__:
             if dimension_key.dimension not in unique_dimensions:
                 unique_dimensions.append(dimension_key.dimension)
-        #
+
         for dimension in unique_dimensions:
             dimension.update(since=since)
         return super(Fact, cls).update(since=since, historical=historical)

--- a/pylytics/library/fact.py
+++ b/pylytics/library/fact.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from contextlib import closing
 import math
 import logging
@@ -72,7 +73,7 @@ class Fact(Table):
         for dimension_key in cls.__dimensionkeys__:
             if dimension_key.dimension not in unique_dimensions:
                 unique_dimensions.append(dimension_key.dimension)
-
+        #
         for dimension in unique_dimensions:
             dimension.update(since=since)
         return super(Fact, cls).update(since=since, historical=historical)

--- a/pylytics/library/table.py
+++ b/pylytics/library/table.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from contextlib import closing
 import logging
 import math


### PR DESCRIPTION
Using unicode for the main internals. Was causing issues when retrieving unicode content from MySQL, which couldn't for example be substituted into a string. For example:

```python
foo = 'hello {}'.format(u'\u2013')
>>> UnicodeEncodeError ...
```