### PR TITLE
Historical dimensions, cleaned up tests, DegenerateDimension

### DIFF
--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -13,6 +13,7 @@ Getting Started
    running-scripts
    scheduling
    source-types
+   table-contraints
    mutable-dimensions
    visualisation-tools
    full-example

--- a/docs/getting-started/running-scripts.rst
+++ b/docs/getting-started/running-scripts.rst
@@ -22,7 +22,7 @@ This will make sure that the relevant tables have been created for the facts spe
 
 
 update
-~~~~~
+~~~~~~
 
 This command automatically calls `build` before executing. It updates your fact and dimension tables.
 
@@ -38,7 +38,21 @@ historical
 
 Facts are usually built each day by running *update*. However, in some cases it's useful to be able to rebuild the tables (for example, if the project is just starting off, or data loss has occurred).
 
-If no `historical_source_query` is defined for the fact, then it raises a warning.
+When the `update` command is run, it gets data from the `__source__` property of the Fact and Dimension classes.
+
+With the `historical` command, it first looks for a `__historical_source__` property of the Fact and Dimension classes. If it exists then it is used instead of `__source__`. Here is an example::
+
+    class Sales(Fact):
+
+        __source__ = DatabaseSource.define(
+            database="sales",
+            query="SELECT * FROM sales_table WHERE created > NOW() - INTERVAL 1 DAY"
+        )
+
+        __historical_source__ = DatabaseSource.define(
+            database="sales",
+            query="SELECT * FROM sales_table"
+        )
 
 
 Specifying the settings file location

--- a/docs/getting-started/table-constraints.rst
+++ b/docs/getting-started/table-constraints.rst
@@ -48,6 +48,6 @@ In situations where the metrics do change, you can use the 'REPLACE INTO' syntax
 
     class MyFact(Fact):
 
-        INSERT = 'REPLACE INTO'
+        INSERT = 'REPLACE'
 
         # ...

--- a/docs/getting-started/table-constraints.rst
+++ b/docs/getting-started/table-constraints.rst
@@ -1,0 +1,53 @@
+Table Constraints
+=================
+
+hash_key
+--------
+
+Pylytics creates the fact and dimension table with certain constraints.
+
+If you look at the fact and dimension tables, they have a column called `hash_key`. This column has a unique constraint.
+
+For a fact table, the hash_key is a hash of all of the dimension values. This is a very important thing to keep in mind when designing your fact tables. The fact row has to be uniquely identified by its dimensions.
+
+In the example below, the fact table is for sales in a retail store.
+
+The dimensions are store, customer, date, and order_id. The metric is sales_amount.
+
+If the order_id dimension wasn't there, and the same customer purchased from the same store twice in one day, the fact table wouldn't be able to record two separate rows.
+
+========  =============== ========== ========= ===================
+Sales
+------------------------------------------------------------------
+store     customer        date       order_id  sales_amount
+========  =============== ========== ========= ===================
+1         12335           400        100       100.00
+1         12335           400        101       10.50
+========  =============== ========== ========= ===================
+
+The dimension can be a DimensionKey, which is a pointer to a row in a dimension table, or a DegenerateDimension, which stores the dimension value in the fact table itself.
+
+Reasoning
+~~~~~~~~~
+
+The hash_key is there for a very important reason. Most of the times when data is inserted into a datawarehouse, there is considerable overlap with data already in the datawarehouse. For example, you might be downloading the last 7 days worth of data from an API each day, and inserting it into the datawarehouse. Perhaps the API only allows you to retrieve data for the last 7 days, or you're concerned about there being missing rows. Either way, the datawarehouse shouldn't create multiple rows for the same data.
+
+
+Insert Types
+------------
+
+By default pylytics inserts data using the 'INSERT IGNORE' syntax for MySQL.
+
+This means that if you try and insert data which has the same dimension values as an existing row, it will fail silently.
+
+This behaviour is fine for *most* cases, but definitely not all.
+
+It works for data sources which don't change after they've been created. For example, the sales fact above. The `sales_amount` shouldn't change after it was created.
+
+In situations where the metrics do change, you can use the 'REPLACE INTO' syntax for MySQL. If you try and insert a row with the same dimension values, it will replace the old row. To do this, add the following to your Fact classes::
+
+    class MyFact(Fact):
+
+        INSERT = 'REPLACE INTO'
+
+        # ...

--- a/docs/getting-started/transform.rst
+++ b/docs/getting-started/transform.rst
@@ -21,14 +21,12 @@ The expansions are simple, testable functions. For example::
         """
         data['created_date'] = data['created_datetime'].date()
         del data['created_datetime']
-        return data
 
 
     def convert_str_to_int(data):
         """ The source returns integers as strings - convert them.
         """
         data['sales'] = int(data['sales'])
-        return data
 
 The ``data`` argument is a dictionary representing a single row.
 

--- a/docs/getting-started/writing-facts-and-dimensions.rst
+++ b/docs/getting-started/writing-facts-and-dimensions.rst
@@ -125,3 +125,16 @@ An example is a user submitted questionnaire, where a lot of the fields have bee
 
         rating = DimensionKey('rating', UserRating, optional=True)
         ...
+
+DegenerateDimension
+*******************
+
+A `DegenerateDimension` stores the dimension value in the fact itself, rather than using a foreign key to a dimension table, as is it the case with `DimensionKey`.
+
+Use `DegenerateDimension` when the dimension doesn't warrant its own table - for example, in a sales fact there might be an order_id. Having this in a separate table doesn't save any space, and results in an unneccessary join.
+
+    class Sales(Fact):
+
+        __source__ = NotImplemented
+
+        order_id = DegenerateDimension('order_id', basestring)

--- a/pylytics/library/column.py
+++ b/pylytics/library/column.py
@@ -130,6 +130,18 @@ class DimensionKey(Column):
         return super(DimensionKey, self).expression + ", " + foreign_key
 
 
+class DegenerateDimension(Column):
+    """ A Fact column that is used to hold a dimension value in the fact table
+    rather than having a foreign key to a separate dimension table. Use it
+    sparingly. It makes sense for dimensions such as 'order number' in a sales
+    fact. Each row will have a unique order number, so moving it out into a
+    separate dimension table doesn't save any space, and results in an
+    unnecessary join.
+    """
+
+    __columnblock__ = 3
+
+
 class Metric(Column):
     """ A column used to store fact metrics.
     """

--- a/pylytics/library/dimension.py
+++ b/pylytics/library/dimension.py
@@ -15,6 +15,10 @@ class Dimension(Table):
     __naturalkeys__ = NotImplemented
     __compositekey__ = NotImplemented
 
+    # Generic columns.
+    id = PrimaryKey()
+    hash_key = HashKey()
+    created = CreatedTimestamp()
     applicable_from = ApplicableFrom()
 
     @classmethod

--- a/pylytics/library/dimension.py
+++ b/pylytics/library/dimension.py
@@ -1,9 +1,8 @@
 from __future__ import unicode_literals
-import datetime
 
 from column import *
 from table import Table
-from utils import dump, escaped, raw_sql
+from utils import dump, escaped
 
 
 class Dimension(Table):
@@ -16,13 +15,7 @@ class Dimension(Table):
     __naturalkeys__ = NotImplemented
     __compositekey__ = NotImplemented
 
-    id = PrimaryKey()
-    hash_key = HashKey()
     applicable_from = ApplicableFrom()
-    created = CreatedTimestamp()
-
-    def __init__(self, *args, **kwargs):
-        self['hash_key'] = raw_sql("UNHEX(SHA1(CONCAT_WS(',', %s)))" % ', '.join(["IFNULL(%s,'NULL')" % escaped(c.name) for c in self.__compositekey__]))
 
     @classmethod
     def __subquery__(cls, value, timestamp):

--- a/pylytics/library/fact.py
+++ b/pylytics/library/fact.py
@@ -47,7 +47,6 @@ class Fact(Table):
     # These attributes aren't touched by the metaclass.
     __dimension_selector__ = DimensionSelector()
     __schedule__ = Schedule()
-    __historical_source__ = None
 
     id = PrimaryKey()
     hash_key = HashKey()

--- a/pylytics/library/fact.py
+++ b/pylytics/library/fact.py
@@ -7,7 +7,7 @@ from exceptions import classify_error
 from schedule import Schedule
 from selector import DimensionSelector
 from table import Table
-from utils import dump, escaped, raw_sql
+from utils import dump, escaped
 from warehouse import Warehouse
 
 
@@ -46,6 +46,11 @@ class Fact(Table):
     # These attributes aren't touched by the metaclass.
     __dimension_selector__ = DimensionSelector()
     __schedule__ = Schedule()
+
+    # Generic columns.
+    id = PrimaryKey()
+    hash_key = HashKey()
+    created = CreatedTimestamp()
 
     @classmethod
     def build(cls):

--- a/pylytics/library/fact.py
+++ b/pylytics/library/fact.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 from contextlib import closing
-import math
 import logging
 
 from column import *
@@ -63,7 +62,8 @@ class Fact(Table):
 
     @classmethod
     def update(cls, since=None, historical=False):
-        if not (cls.__historical_source__ if historical else cls.__source__):
+        if not (cls.__historical_source__ if historical and
+                cls.__historical_source__ else cls.__source__):
             # Bail early before building dimensions.
             raise NotImplementedError("No data source defined")
 

--- a/pylytics/library/fact.py
+++ b/pylytics/library/fact.py
@@ -52,7 +52,11 @@ class Fact(Table):
     created = CreatedTimestamp()
 
     def __init__(self, *args, **kwargs):
-        self['hash_key'] = raw_sql("UNHEX(SHA1(CONCAT_WS(',', %s)))" % ', '.join(["IFNULL(%s,'NULL')" % escaped(c.name) for c in self.__compositekey__]))
+        values = ', '.join(
+            ["IFNULL(%s,'NULL')" % escaped(c.name) for c in
+             self.__compositekey__]
+            )
+        self['hash_key'] = raw_sql("UNHEX(SHA1(CONCAT_WS(',', %s)))" % values)
 
     @classmethod
     def build(cls):

--- a/pylytics/library/fact.py
+++ b/pylytics/library/fact.py
@@ -47,17 +47,6 @@ class Fact(Table):
     __dimension_selector__ = DimensionSelector()
     __schedule__ = Schedule()
 
-    id = PrimaryKey()
-    hash_key = HashKey()
-    created = CreatedTimestamp()
-
-    def __init__(self, *args, **kwargs):
-        values = ', '.join(
-            ["IFNULL(%s,'NULL')" % escaped(c.name) for c in
-             self.__compositekey__]
-            )
-        self['hash_key'] = raw_sql("UNHEX(SHA1(CONCAT_WS(',', %s)))" % values)
-
     @classmethod
     def build(cls):
         for dimension_key in cls.__dimensionkeys__:

--- a/pylytics/library/fact.py
+++ b/pylytics/library/fact.py
@@ -75,7 +75,7 @@ class Fact(Table):
                 unique_dimensions.append(dimension_key.dimension)
 
         for dimension in unique_dimensions:
-            dimension.update(since=since)
+            dimension.update(since=since, historical=historical)
         return super(Fact, cls).update(since=since, historical=historical)
 
     # TODO Consider adding historical to dimensions.

--- a/pylytics/library/table.py
+++ b/pylytics/library/table.py
@@ -117,6 +117,7 @@ class Table(object):
     __tablename__ = NotImplemented
 
     # These attributes aren't touched by the metaclass.
+    __historical_source__ = None
     __source__ = None
     __tableargs__ = {
         "ENGINE": "InnoDB",
@@ -249,7 +250,8 @@ class Table(object):
         """ Fetch data from the source defined for this table and
         yield as each is received.
         """
-        source = cls.__historical_source__ if historical else cls.__source__
+        source = (cls.__historical_source__ if historical and
+                  cls.__historical_source__ else cls.__source__)
         if source:
             try:
                 for inst in source.select(cls, since=since):

--- a/pylytics/library/table.py
+++ b/pylytics/library/table.py
@@ -127,10 +127,6 @@ class Table(object):
 
     INSERT = "INSERT IGNORE"
 
-    id = PrimaryKey()
-    hash_key = HashKey()
-    created = CreatedTimestamp()
-
     def __init__(self, *args, **kwargs):
         values = ', '.join(
             ["IFNULL(%s,'NULL')" % escaped(c.name) for c in

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,21 +4,6 @@ import pytest
 from test.helpers import db_fixture, execute
 
 
-CREATE_STAGING_TABLE = """\
-CREATE TABLE `staging` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `collector_type` varchar(127) NOT NULL,
-  `fact_table` varchar(255) NOT NULL,
-  `value_map` text NOT NULL,
-  `created` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`),
-  KEY `collector_type` (`collector_type`),
-  KEY `fact_table` (`fact_table`),
-  KEY `created` (`created`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-"""
-
-
 @pytest.fixture(scope="session")
 def warehouse():
     return db_fixture("test_warehouse")
@@ -41,10 +26,3 @@ def empty_warehouse(warehouse):
     execute(warehouse, "SET foreign_key_checks = 1")
     warehouse.commit()
     return warehouse
-
-
-@pytest.fixture
-def staging(warehouse):
-    execute(warehouse, "DROP TABLE IF EXISTS staging")
-    execute(warehouse, CREATE_STAGING_TABLE)
-    warehouse.commit()

--- a/test/default_settings.py
+++ b/test/default_settings.py
@@ -6,11 +6,5 @@ DATABASES = {
         "user": "root",
         "passwd": "",
         "db": "test_warehouse",
-    },
-    "middle_earth": {
-        "host": "localhost",
-        "user": "root",
-        "passwd": "",
-        "db": "middle_earth",
-    },
+    }
 }

--- a/test/dummy_project/__init__.py
+++ b/test/dummy_project/__init__.py
@@ -9,23 +9,42 @@ and not in conftest.
 from pylytics.library.column import Column, DimensionKey, Metric, NaturalKey
 from pylytics.library.dimension import Dimension
 from pylytics.library.fact import Fact
+from pylytics.library.source import CallableSource
+
+
+STORES = [
+    {'store_id': 1, 'manager': 'Mrs Smith'},
+    {'store_id': 2, 'manager': 'Dr Pepper'}
+]
+
+PRODUCTS = [
+    {'product_id': 1, 'manager': 'Jeans'},
+    {'product_id': 2, 'manager': 'Cheese'}
+]
 
 
 class Store(Dimension):
-    __source__ = NotImplemented
+
+    __source__ = CallableSource.define(
+        _callable=staticmethod(lambda: STORES)
+    )
 
     store_id = NaturalKey('store_id', int, size=10)
     manager = Column('manager', str, size=100)
 
 
 class Product(Dimension):
-    __source__ = NotImplemented
+
+    __source__ = CallableSource.define(
+        _callable=staticmethod(lambda: PRODUCTS)
+    )
 
     product_id = NaturalKey('product_id', int, size=10)
     product_name = Column('product_name', str, size=100)
 
 
 class Sales(Fact):
+
     __source__ = NotImplemented
 
     product = DimensionKey('product', Product)
@@ -33,6 +52,7 @@ class Sales(Fact):
 
 
 class Stock(Fact):
+
     __source__ = NotImplemented
 
     product = DimensionKey('product', Product)

--- a/test/dummy_project/__init__.py
+++ b/test/dummy_project/__init__.py
@@ -6,7 +6,8 @@ and not in conftest.
 
 """
 
-from pylytics.library.column import Column, DimensionKey, Metric, NaturalKey
+from pylytics.library.column import (Column, DimensionKey, Metric, NaturalKey,
+                                     DegenerateDimension)
 from pylytics.library.dimension import Dimension
 from pylytics.library.fact import Fact
 from pylytics.library.source import CallableSource
@@ -57,3 +58,12 @@ class Stock(Fact):
 
     product = DimensionKey('product', Product)
     quantity = Metric('quantity', int)
+
+
+class StockWithCode(Fact):
+
+    __source__ = NotImplemented
+
+    product = DimensionKey('product', Product)
+    quantity = Metric('quantity', int)
+    stock_code = DegenerateDimension('stock_code', basestring)

--- a/test/dummy_project/__init__.py
+++ b/test/dummy_project/__init__.py
@@ -23,6 +23,8 @@ PRODUCTS = [
     {'product_id': 2, 'manager': 'Cheese'}
 ]
 
+################################################################################
+# Dimensions
 
 class Store(Dimension):
 
@@ -44,6 +46,9 @@ class Product(Dimension):
     product_name = Column('product_name', str, size=100)
 
 
+################################################################################
+# Facts
+
 class Sales(Fact):
 
     __source__ = NotImplemented
@@ -55,6 +60,14 @@ class Sales(Fact):
 class Stock(Fact):
 
     __source__ = NotImplemented
+
+    product = DimensionKey('product', Product)
+    quantity = Metric('quantity', int)
+
+
+class StockReplace(Fact):
+
+    INSERT = 'REPLACE'
 
     product = DimensionKey('product', Product)
     quantity = Metric('quantity', int)

--- a/test/helpers/__init__.py
+++ b/test/helpers/__init__.py
@@ -13,7 +13,6 @@ def execute(connection, statement):
     cursor.close()
 
 
-# TODO This is redundant now - use get_named_connection instead.
 def db_fixture(database):
     """ Create and return a database fixture based on details from the
     global database settings.

--- a/test/integration/performance/test_performance.py
+++ b/test/integration/performance/test_performance.py
@@ -17,7 +17,7 @@ from test.dummy_project import Product, Sales, Store
 
 
 # The fact table generated is MAX_ITERATIONS ^ 2.
-MAX_ITERATIONS = 1001
+MAX_ITERATIONS = 101
 
 log = logging.getLogger("pylytics")
 

--- a/test/unit/library/test_column.py
+++ b/test/unit/library/test_column.py
@@ -1,0 +1,11 @@
+import pytest
+
+from pylytics.library.column import Column
+
+
+class TestColumnCreation(object):
+
+    def test_cannot_create_a_column_with_an_odd_type(self):
+        column = Column("foo", object)
+        with pytest.raises(TypeError):
+            _ = column.type_expression

--- a/test/unit/library/test_dimension.py
+++ b/test/unit/library/test_dimension.py
@@ -95,3 +95,30 @@ class TestEvolvingDimensions(object):
         Store.insert(store)
         Store.insert(null_store)
         assert self._fetch_store_row_count() == 2
+
+################################################################################
+
+def test_can_create_dimension(empty_warehouse):
+    Warehouse.use(empty_warehouse)
+    assert Store.create_table()
+    assert Store.table_exists
+
+
+def test_cannot_create_dimension_twice(empty_warehouse):
+    Warehouse.use(empty_warehouse)
+    assert Store.create_table()
+    assert not Store.create_table()
+
+
+def test_dimension_has_sensible_defaults():
+    assert Store.__tablename__ == "store_dimension"
+    columns = Store.__columns__
+    assert columns[0].name == "id"
+    assert columns[-1].name == "created"
+
+
+def test_can_drop_dimension(empty_warehouse):
+    Warehouse.use(empty_warehouse)
+    Store.create_table()
+    Store.drop_table()
+    assert not Store.table_exists

--- a/test/unit/library/test_fact.py
+++ b/test/unit/library/test_fact.py
@@ -11,8 +11,8 @@ from pylytics.library.dimension import Dimension
 from pylytics.library.fact import Fact
 from pylytics.library.source import CallableSource
 from pylytics.library.warehouse import Warehouse
-from test.dummy_project import (Product, Sales, Stock, Store, PRODUCTS,
-                                StockWithCode)
+from test.dummy_project import (Product, Sales, Stock, StockReplace, Store,
+                                PRODUCTS, StockWithCode)
 
 
 log = logging.getLogger("pylytics")
@@ -57,10 +57,10 @@ class TestColumnTypes(object):
 
 class TestFactRowInsertion(object):
 
-    def _fetch_stock(self):
+    def _fetch_rows(self, fact_class):
         connection = Warehouse.get()
         with closing(connection.cursor(dictionary=True)) as cursor:
-            cursor.execute('SELECT * FROM %s' % Stock.__tablename__)
+            cursor.execute('SELECT * FROM %s' % fact_class.__tablename__)
             rows = cursor.fetchall()
         return rows
 
@@ -76,7 +76,91 @@ class TestFactRowInsertion(object):
         Stock.insert(fact_1)
 
         # Fetch that row back and make sure it's ok.
-        rows = self._fetch_stock()
+        rows = self._fetch_rows(Stock)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["quantity"] == 5
+
+    def test_duplicate_rows(self, empty_warehouse):
+        """ An identical row, with the same dimension values, shouldn't get
+        duplicated when inserted twice.
+        """
+        Warehouse.use(empty_warehouse)
+        Stock.build()
+        Product.update()
+
+        # Create a fact row.
+        fact_1 = Stock()
+        fact_1.product = PRODUCTS[0]['product_id']
+        fact_1.quantity = 5
+
+        # Insert the fact twice
+        Stock.insert(fact_1)
+        Stock.insert(fact_1)
+
+        # Also try inserting the same fact, with the same dimension values but
+        # different metric values.
+        fact_1.quantity = 4
+        Stock.insert(fact_1)
+
+        # Fetch that row back and make sure it's ok.
+        rows = self._fetch_rows(Stock)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["quantity"] == 5
+
+    def test_replace_into(self, empty_warehouse):
+        """ Test inserting two facts with the same dimensions, but with
+        REPLACE_INTO as the insert method.
+        """
+        Warehouse.use(empty_warehouse)
+        StockReplace.build()
+        Product.update()
+
+        # Create a fact row.
+        fact_1 = StockReplace()
+        fact_1.product = PRODUCTS[0]['product_id']
+        fact_1.quantity = 5
+
+        # Insert the fact
+        StockReplace.insert(fact_1)
+
+        # Insert the same fact, with the same dimension values but
+        # different metric values.
+        fact_1.quantity = 4
+        StockReplace.insert(fact_1)
+
+        # Fetch that row back and make sure it's ok.
+        rows = self._fetch_rows(StockReplace)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["quantity"] == 4
+
+    def test_degenerate_dimension_uniqueness(self, empty_warehouse):
+        """ Make sure that facts which contain degenerate dimensions behave the
+        same (i.e. no duplicates inserted).
+        """
+        Warehouse.use(empty_warehouse)
+        StockWithCode.build()
+        Product.update()
+
+        # Create a fact row.
+        fact_1 = StockWithCode()
+        fact_1.product = PRODUCTS[0]['product_id']
+        fact_1.quantity = 5
+        fact_1.stock_code = 'abcdefg'
+
+        # Insert the fact twice
+        StockWithCode.insert(fact_1)
+        StockWithCode.insert(fact_1)
+
+        # Also try inserting the same fact, with the same dimension values but
+        # different metric values.
+        fact_1.quantity = 4
+        Stock.insert(fact_1)
+
+        # Fetch that row back and make sure it's ok.
+        rows = self._fetch_rows(StockWithCode)
         assert len(rows) == 1
         row = rows[0]
         assert row["quantity"] == 5

--- a/test/unit/library/test_fact.py
+++ b/test/unit/library/test_fact.py
@@ -11,7 +11,8 @@ from pylytics.library.dimension import Dimension
 from pylytics.library.fact import Fact
 from pylytics.library.source import CallableSource
 from pylytics.library.warehouse import Warehouse
-from test.dummy_project import Product, Sales, Stock, Store, PRODUCTS
+from test.dummy_project import (Product, Sales, Stock, Store, PRODUCTS,
+                                StockWithCode)
 
 
 log = logging.getLogger("pylytics")
@@ -45,6 +46,13 @@ class TestFactTableCreation(object):
         assert Product.table_exists
         assert Store.table_exists
         assert Sales.table_exists
+
+
+class TestColumnTypes(object):
+
+    def test_degenerate_dimension(self, empty_warehouse):
+        Warehouse.use(empty_warehouse)
+        StockWithCode.build()
 
 
 class TestFactRowInsertion(object):

--- a/test/unit/library/test_fact.py
+++ b/test/unit/library/test_fact.py
@@ -3,315 +3,87 @@
 from __future__ import unicode_literals
 
 from contextlib import closing
-from datetime import date, time, timedelta
 import logging
 
-import pytest
-
 from pylytics.library.warehouse import Warehouse
-from pylytics.library.source import DatabaseSource, Staging
-from pylytics.library.column import (Column, DimensionKey, Metric,
-                                     NaturalKey)
-from pylytics.library.dimension import Dimension
-from pylytics.library.fact import Fact
-from pylytics.library.utils import escaped
-from pylytics.library.exceptions import TableExistsError
-from test.dummy_project import Sales
+from test.dummy_project import Product, Sales, Stock, Store, PRODUCTS
 
 
 log = logging.getLogger("pylytics")
 
 
-class Date(Dimension):
-    __tablename__ = "dim_date"
+class TestFactTableCreation(object):
+    """ Test that the fact table can be created, if the corresponding dimension
+    tables are partially, fully, or not created.
+    """
 
-    # Just use a fixed three year period for testing.
-    start_date = date(1999, 1, 1)
-    end_date = date(2001, 12, 31)
+    def test_can_create_fact_if_no_dimensions_exist(self, empty_warehouse):
+        Warehouse.use(empty_warehouse)
+        Sales.build()
+        assert Sales.table_exists
+        assert Product.table_exists
+        assert Store.table_exists
 
-    day_names = ('Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun')
-    month_names = ('Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-                   'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec')
+    def test_can_create_fact_if_some_dimensions_exist(self, empty_warehouse):
+        Warehouse.use(empty_warehouse)
+        Product.create_table()
+        Sales.build()
+        assert Sales.table_exists
+        assert Store.table_exists
+        assert Product.table_exists
 
-    date = NaturalKey("date", date)
-    date_string = NaturalKey("date_string", unicode)
-    day = Column("day", int)
-    day_name = Column("day_name", day_names)
-    day_of_week = Column("day_of_week", int)
-    week = Column("week", int)
-    full_week = Column("full_week", unicode, size=15)
-    month = Column("month", int)
-    month_name = Column("month_name", month_names)
-    full_month = Column("full_name", unicode, size=15)
-    quarter = Column("quarter", int)
-    quarter_name = Column("quarter_name", ('Q1', 'Q2', 'Q3', 'Q4'))
-    full_quarter = Column("full_quarter", unicode, size=15)
-    year = Column("year", int)
+    def test_can_create_fact_if_all_dimensions_exist(self, empty_warehouse):
+        Warehouse.use(empty_warehouse)
+        Product.create_table()
+        Store.create_table()
+        Sales.build()
+        assert Product.table_exists
+        assert Store.table_exists
+        assert Sales.table_exists
 
-    # TODO This is an old school dimension. Should be using CallableSource.
-    @classmethod
-    def fetch(cls, since=None, historical=False):
-        """ Create date instances as there's no remote data source
-        for this one.
-        """
-        table_name = cls.__tablename__
-        log.info("Fetching data from the depths of time itself",
-                 extra={"table_name": table_name})
 
-        # Get the last inserted date
-        sql = "SELECT MAX(`date`) FROM %s" % escaped(table_name)
+class TestFactRowInsertion(object):
+
+    def _fetch_stock(self):
         connection = Warehouse.get()
-        cursor = connection.cursor()
-        cursor.execute(sql)
-        cur_date = cursor.fetchall()[0][0]
-        cursor.close()
+        with closing(connection.cursor(dictionary=True)) as cursor:
+            cursor.execute('SELECT * FROM %s' % Stock.__tablename__)
+            rows = cursor.fetchall()
+        return rows
 
-        if cur_date is None:
-            # Build history.
-            cur_date = cls.start_date
+    def test_can_insert_fact_record(self, empty_warehouse):
+        Warehouse.use(empty_warehouse)
+        Stock.build()
+        Product.update()
 
-        dates = []
-        while cur_date <= cls.end_date:
-            yield Date(cur_date)
-            cur_date = cur_date + timedelta(days=1)
+        # Insert a fact row.
+        fact_1 = Stock()
+        fact_1.product = PRODUCTS[0]['product_id']
+        fact_1.quantity = 5
+        Stock.insert(fact_1)
 
-    def __init__(self, date_obj):
-        quarter = (date_obj.month - 1) // 3 + 1
-        self.date = date_obj
-        self.date_string = date_obj.strftime("%Y-%m-%d")
-        self.day = date_obj.day
-        self.day_name = date_obj.strftime("%a")          # e.g. Mon
-        self.day_of_week = int(date_obj.strftime("%u"))  # ISO day no of week
-        self.week = int(date_obj.strftime("%U"))         # ISO week number
-        self.full_week = date_obj.strftime("%Y-%U")      # Year and week no
-        self.month = int(date_obj.strftime("%m"))        # Month number
-        self.month_name = date_obj.strftime("%b")        # Month name
-        self.full_month = date_obj.strftime("%Y-%m")     # Year and month
-        self.quarter = quarter                           # Quarter no
-        self.quarter_name = "Q{}".format(quarter)        # e.g. Q1
-        self.full_quarter = '{0}-{1}'.format(date_obj.year, quarter)
-        self.year = date_obj.year
-        super(Date, self).__init__()
+        # Fetch that row back and make sure it's ok.
+        rows = self._fetch_stock()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["quantity"] == 5
 
 
-@pytest.fixture
-def place_source(empty_warehouse):
-    cursor = empty_warehouse.cursor()
-    cursor.execute("CREATE TABLE place_source(code varchar(40))")
-    cursor.execute("INSERT INTO place_source(code) VALUES('MOON')")
-    cursor.close()
-    empty_warehouse.commit()
-
-
-class Place(Dimension):
-
-    # This class method creates a custom subclass of `DatabaseSource`
-    # that selects using a SQL query.
-    __source__ = DatabaseSource.define(
-        database="test_warehouse",
-        query="select code as geo_code from place_source",
-    )
-
-    geo_code = NaturalKey("geo_code", unicode, size=20)
-
-
-# We have to declare this outside the class below as staticmethods
-# and classmethods cannot be referenced without a class instance.
-def expand_duration(data):
-    """ Example expansion function. This one simply adds a
-    unit for the duration.
+class TestTriggers(object):
+    """ Triggers are created to get around limitations of multiple timestamp
+    values in MySQL. Make sure they can be created.
     """
-    data["duration_unit"] = "s"
 
+    def test_create_trigger(self, empty_warehouse):
+        """ Make sure a trigger can be created.
+        """
+        Warehouse.use(empty_warehouse)
+        Sales.build()
+        assert Sales.trigger_name in Warehouse.trigger_names
 
-class BoringEvent(Fact):
-    __tablename__ = "boring_event_fact"
-
-    # This class method creates a custom subclass of `Staging`
-    # that filters only "boring" events. One expansion is also
-    # defined to explode the "expansion_key_1" value into more
-    # values drawn from the defined database source. This
-    # mechanism can be used to seek further details on
-    # bookings, etc.
-    __source__ = Staging.define(
-        events=["boring"],
-        expansions=[
-            DatabaseSource.define(
-                database="test_warehouse",
-                query="""\
-                SELECT
-                    colour AS colour_of_stuff,
-                    size AS size_of_stuff
-                FROM extra_table
-                WHERE id = {expansion_key_1}
-                """,
-            ),
-            expand_duration,
-        ],
-    )
-
-    date = DimensionKey("when", Date)
-    place = DimensionKey("where", Place)
-    people = Metric("num_people", int)
-    duration = Metric("duration", float)
-    duration_unit = Metric("duration_unit", unicode, size=2, optional=True)
-    very_boring = Metric("very_boring", bool)
-    stuff_colour = Metric("colour_of_stuff", unicode, optional=True)
-    stuff_size = Metric("size_of_stuff", unicode, optional=True)
-
-
-### TESTS ###
-
-
-def test_cannot_create_a_column_with_an_odd_type():
-    column = Column("foo", object)
-    with pytest.raises(TypeError):
-        _ = column.type_expression
-
-
-def test_can_create_dimension(empty_warehouse):
-    Warehouse.use(empty_warehouse)
-    assert Date.create_table()
-    assert Date.table_exists
-
-
-def test_cannot_create_dimension_twice(empty_warehouse):
-    Warehouse.use(empty_warehouse)
-    assert Date.create_table()
-    assert not Date.create_table()
-
-
-def test_dimension_has_sensible_defaults():
-    assert Place.__tablename__ == "place_dimension"
-    columns = Place.__columns__
-    assert columns[0].name == "id"
-    assert columns[-1].name == "created"
-
-
-def test_can_drop_dimension(empty_warehouse):
-    Warehouse.use(empty_warehouse)
-    Date.create_table()
-    Date.drop_table()
-    assert not Date.table_exists
-
-
-def test_can_create_fact_if_no_dimensions_exist(empty_warehouse):
-    Warehouse.use(empty_warehouse)
-    BoringEvent.build()
-    assert BoringEvent.table_exists
-    assert Date.table_exists
-    assert Place.table_exists
-
-
-def test_can_create_fact_if_some_dimensions_exist(empty_warehouse):
-    Warehouse.use(empty_warehouse)
-    Date.create_table()
-    BoringEvent.build()
-    assert BoringEvent.table_exists
-    assert Date.table_exists
-    assert Place.table_exists
-
-
-def test_can_create_fact_if_all_dimensions_exist(empty_warehouse):
-    Warehouse.use(empty_warehouse)
-    Date.create_table()
-    Place.create_table()
-    BoringEvent.build()
-    assert BoringEvent.table_exists
-    assert Date.table_exists
-    assert Place.table_exists
-
-
-@pytest.mark.usefixtures("place_source")
-def test_can_insert_fact_record(empty_warehouse):
-    Warehouse.use(empty_warehouse)
-
-    BoringEvent.build()
-    Date.update()
-    Place.update()
-
-    fact_1 = BoringEvent()
-    fact_1.date = date(2000, 7, 16)
-    fact_1.place = "MOON"
-    fact_1.people = 3
-    fact_1.duration = 10.7
-    fact_1.very_boring = False
-    BoringEvent.insert(fact_1)
-
-    connection = Warehouse.get()
-    cursor = connection.cursor(dictionary=True)
-    cursor.execute("select * from %s" % BoringEvent.__tablename__)
-    data = cursor.fetchall()
-    cursor.close()
-    assert len(data) == 1
-    datum = data[0]
-    assert datum["num_people"] == 3
-    assert datum["duration"] == 10.7
-    assert bool(datum["very_boring"]) is False
-
-
-@pytest.mark.usefixtures("place_source")
-def test_can_insert_fact_record_from_staging_source(empty_warehouse):
-    Warehouse.use(empty_warehouse)
-    Staging.build()
-    BoringEvent.build()
-
-    # Prepare expansion data ready for expansion.
-    connection = Warehouse.get()
-    with closing(connection.cursor()) as cursor:
-        cursor.execute("""\
-        create table extra_table (
-            id int primary key,
-            colour varchar(20),
-            size varchar(20)
-        ) charset=utf8 collate=utf8_bin
-        """)
-        cursor.execute("""\
-        insert into extra_table (id, colour, size)
-        values (12, 'grün', '37kg'), (13, 'orange', '9 miles')
-        """)
-    connection.commit()
-
-    # Insert staging record.
-    Staging.insert(Staging("boring", {
-        "when": date(2000, 7, 16).isoformat(),
-        "where": "MOON",
-        "num_people": 3,
-        "duration": 10.7,
-        "very_boring": False,
-        "pointless_ignored_value": "spoon",
-        "expansion_key_1": 12,
-    }))
-
-    # Perform update.
-    BoringEvent.update()
-
-    # Check a record has been correctly inserted.
-    with closing(connection.cursor(dictionary=True)) as cursor:
-        cursor.execute("select * from %s" % BoringEvent.__tablename__)
-        data = cursor.fetchall()
-
-    assert len(data) == 1
-    datum = data[0]
-    assert datum["num_people"] == 3
-    assert datum["duration"] == 10.7
-    assert bool(datum["very_boring"]) is False
-    # mysql returns unicode as bytearrays.
-    assert datum["colour_of_stuff"].decode('utf8') == u"grün"
-    assert datum["size_of_stuff"].decode('utf8') == "37kg"
-
-
-def test_create_trigger(empty_warehouse):
-    """ Make sure a trigger can be created.
-    """
-    Warehouse.use(empty_warehouse)
-    Sales.build()
-    assert Sales.trigger_name in Warehouse.trigger_names
-
-
-def test_create_duplicate_trigger(empty_warehouse):
-    """ Make sure a trigger isn't created if one already exists.
-    """
-    Warehouse.use(empty_warehouse)
-    Sales.build()
-    assert not Sales.create_trigger()
+    def test_create_duplicate_trigger(self, empty_warehouse):
+        """ Make sure a trigger isn't created if one already exists.
+        """
+        Warehouse.use(empty_warehouse)
+        Sales.build()
+        assert not Sales.create_trigger()

--- a/test/unit/library/test_source.py
+++ b/test/unit/library/test_source.py
@@ -1,0 +1,4 @@
+class TestSource(object):
+
+    def test_expansions(self):
+        pass

--- a/test/unit/library/test_source.py
+++ b/test/unit/library/test_source.py
@@ -1,4 +1,46 @@
-class TestSource(object):
+from contextlib import closing
 
-    def test_expansions(self):
-        pass
+from pylytics.library.column import NaturalKey
+from pylytics.library.dimension import Dimension
+from pylytics.library.source import CallableSource
+from pylytics.library.warehouse import Warehouse
+
+################################################################################
+
+def add_surname(row):
+    row['name'] = row['name'] + ' Flintstone'
+
+
+class Person(Dimension):
+    __source__ = CallableSource.define(
+        _callable=staticmethod(lambda: [
+            {'name': 'Fred'},
+            {'name': 'Wilma'},
+            {'name': 'Pebbles'}
+        ]),
+        expansions=[add_surname]
+    )
+    name = NaturalKey('name', basestring)
+
+################################################################################
+
+class TestExpansions(object):
+
+    def _get_rows(self):
+        connection = Warehouse.get()
+        with closing(connection.cursor(dictionary=True)) as cursor:
+            cursor.execute('SELECT * FROM %s' % Person.__tablename__)
+            rows = cursor.fetchall()
+        return rows
+
+    def test_expansions(self, empty_warehouse):
+        """ Make sure the expansions are being called, and are manipulating
+        the data.
+        """
+        Person.build()
+        Person.update()
+        rows = self._get_rows()
+        names = [str(i['name']) for i in rows]
+        assert ('Fred Flintstone' in names and
+                'Wilma Flintstone' in names and
+                'Pebbles Flintstone' in names)


### PR DESCRIPTION
* Historical dimensions - a __historical_source__ can now be specified for Dimension subclasses, which will be tried first when doing a historical update of a Fact. If it's not available, it will fall back to __source__.
* Cleaned up tests - removed some old cruft. Added tests for unique constraints on tables.
* DegenerateDimension - providing this new column type for storing dimension values in the Fact table, rather than using a foreign key to a separate Dimension table. Used sparingly, it's very useful.