### PR TITLE
cleaned up README, and setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,50 +3,26 @@ pylytics
 
 Introduction
 ************
-This is a set of Python libraries that allow you to build and manage a `star schema <http://en.wikipedia.org/wiki/Star_schema>`_.
+This is a set of Python libraries that allow you to build and manage a `star schema <http://en.wikipedia.org/wiki/Star_schema>`_ in MySQL.
 
-The star schema is a simple approach to data warehousing. In contrast to big data tools, the star schema is suited to mid-size data problems.
-
-Its biggest benefit is the strict generation and management of facts.
+The star schema is a simple approach to data warehousing, which is suited to mid-size data problems.
 
 
-facts and dimensions
---------------------
-The pylitics project creates a set of *facts* based on *dimensions*.
+MySQL
+-----
 
-Dimensions are the finite data sets you wish to measure your facts against. Common dimensions include dates, lists of customers and sizes/colours.
+Pylytics has been tested with MySQL versions 5.5.37 and 5.6.5. The recommended version is 5.6.5.
 
-Facts are the measurements you take.  They are most often calculations or summations. Example facts include gross sales by colour per day, total clicks per customer and customers added per week.
+
+Installation
+************
+
+Pylytics uses Oracle's MySQL adapter, which isn't hosted on PyPi:
+
+    pip install --allow-external mysql-connector-python pylytics
 
 
 Documentation
 *************
+
 The full documentation is available at `readthedocs.org <https://pylytics.readthedocs.org/en/latest/index.html>`_
-
-
-Version 1
-*********
-
-Version 1 of pylytics is a considerable departure from the previous stable version (v.0.7.0).
-
-Projects created using pylytics versions < 1.0 are not compatible with pylytics >= 1.0.
-
-We recommend you version pin your old pylytics projects to v.0.7.0.
-
-
-Installing the MySQL connector
-******************************
-
-Pylytics v1 uses Oracle's Python MySQL adapter. It can be installed using pip, but isn't hosted on PyPi.
-
-Depending on your version of pip, you may need to install the requirements as follows::
-
-    pip install -r requirements.txt --allow-external mysql-connector-python
-
-
-Supported MySQL version
-***********************
-
-Pylytics has been tested with MySQL versions 5.5.37 and 5.6.5.
-
-The recommended version is 5.6.5.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
+--allow-external mysql-connector-python
+mysql-connector-python>=2.0.4
 pytz
 iso8601
 raven
-mysql-connector-python>=2.0.4
 Jinja2==2.7.2

--- a/setup.py
+++ b/setup.py
@@ -5,52 +5,52 @@ use_setuptools()
 from setuptools import setup, find_packages
 
 
-here = os.path.abspath(os.path.dirname(__file__))
-make_abs = lambda fn: os.path.join(here, fn)
+HERE = os.path.abspath(os.path.dirname(__file__))
 
 
-def parse_requirements(fn, dependency_links):
+make_abs = lambda fn: os.path.join(HERE, fn)
+
+
+def parse_requirements():
+    """Extract requirements from requirements.txt file.
+    """
+    path = make_abs('requirements.txt')
+
     requirements = []
 
-    if not os.path.exists(fn):
-        return requirements, dependency_links
+    if not os.path.exists(path):
+        return requirements
 
-    with open(fn, 'r') as f:
+    with open(path, 'r') as f:
         for dep in f:
             dep = dep.strip()
-            # need to make github requirements work with
-            # setuptools like it would work with `pip -r`
-            # URLs will not work, so we transform them to
-            # dependency_links and requirements
-            if dep.startswith('git+'):
-                dependency_links.append(dep)
-                _, dep = dep.rsplit('#egg=', 1)
-                dep = dep.replace('-', '==', 1)
+
+            # Lines beginning with -- are instructions to pip about how to
+            # process the requirements. There are no equivalents in setuptools.
+            # An example is `--allow-external some-python-package`.
+            if dep.startswith('--'):
+                continue
+
             requirements.append(dep)
 
-    return requirements, dependency_links
-
-
-requirements, dependency_links = parse_requirements(
-    make_abs('requirements.txt'), [])
+    return requirements
 
 
 setup(
     author='onefinestay',
     author_email='engineering@onefinestay.com',
     classifiers=[
-      "Development Status :: 4 - Beta",
-      "Programming Language :: Python :: 2.7",
-      "Intended Audience :: Developers",
-      "Natural Language :: English",
-      "Topic :: Software Development",
-      "Topic :: Utilities",
-      "Environment :: Console",
+        "Development Status :: 4 - Beta",
+        "Programming Language :: Python :: 2.7",
+        "Intended Audience :: Developers",
+        "Natural Language :: English",
+        "Topic :: Software Development",
+        "Topic :: Utilities",
+        "Environment :: Console"
     ],
-    dependency_links=dependency_links,
     description='Build and manage a star schema.',
     include_package_data=True,
-    install_requires=requirements,
+    install_requires=parse_requirements(),
     long_description=open(make_abs('README.rst')).read(),
     name='pylytics',
     packages=find_packages(exclude=("test", "test.*")),


### PR DESCRIPTION
 * Cleaned up README - most of it was duplicated from the main docs.
 * Added `--allow-external` line to requirements.txt, so it can be installed locally via pip without additional flags.
 * Removed unused crud from setup.py.