### PR TITLE
using a fork of oracle's mysql adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
     - 2.7
 install:
-    - pip install -r requirements.txt --allow-external mysql-connector-python
+    - pip install -r requirements.txt
     - pip install -r test_requirements.txt
 script:
     - ./run_unit_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
     - 2.7
 install:
+    - pip install -U pip
     - pip install -r requirements.txt
     - pip install -r test_requirements.txt
 script:

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,8 @@ Pylytics has been tested with MySQL versions 5.5.37 and 5.6.5. The recommended v
 Installation
 ************
 
+Using a recent version of pip (tested with version 8.1.2):
+
     pip install pylytics
 
 

--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,7 @@ Pylytics has been tested with MySQL versions 5.5.37 and 5.6.5. The recommended v
 Installation
 ************
 
-Pylytics uses Oracle's MySQL adapter, which isn't hosted on PyPi:
-
-    pip install --allow-external mysql-connector-python pylytics
+    pip install pylytics
 
 
 Documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
---allow-external mysql-connector-python
-mysql-connector-python>=2.0.4
+mysql-connector>=2.1.3
 pytz
 iso8601
 raven


### PR DESCRIPTION
Oracle seem incapable of making their mysql adapter available on pypi. Using a fork which is properly hosted.